### PR TITLE
lifecycle-support, useSensor-support iOS

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/nativedeviceorientation/NativeDeviceOrientationPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/nativedeviceorientation/NativeDeviceOrientationPlugin.java
@@ -59,9 +59,32 @@ public class NativeDeviceOrientationPlugin implements MethodCallHandler, EventCh
                     result.success(reader.getOrientation().name());
                 }
 
+            case "pause":
+                pause();
+                result.success(null);
+                break;
+
+            case "resume":
+                resume();
+                result.success(null);
                 break;
             default:
                 result.notImplemented();
+        }
+    }
+
+
+    private void pause(){
+        // if a listener is currently active, stop listening. The app is going to the background
+        if(listener != null){
+            listener.stopOrientationListener();
+        }
+    }
+
+    private void resume(){
+        // start listening for orientation changes again. The app is in the foreground.
+        if(listener != null){
+            listener.startOrientationListener();
         }
     }
 

--- a/ios/Classes/IOrientationListener.h
+++ b/ios/Classes/IOrientationListener.h
@@ -1,0 +1,12 @@
+#ifndef IOrientationListener_h
+#define IOrientationListener_h
+
+@protocol IOrientationListener <NSObject>
+
+- (void) startOrientationListener:(void (^)(NSString* orientation)) orientationRetrieved;
+- (void) stopOrientationListener;
+- (void) getOrientation:(void (^)(NSString* orientation)) orientationRetrieved;
+
+@end
+
+#endif

--- a/ios/Classes/NativeDeviceOrientationPlugin.h
+++ b/ios/Classes/NativeDeviceOrientationPlugin.h
@@ -1,5 +1,4 @@
 #import <Flutter/Flutter.h>
-#import <CoreMotion/CoreMotion.h>
 
 @interface NativeDeviceOrientationPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
 - (void)pause;

--- a/ios/Classes/NativeDeviceOrientationPlugin.h
+++ b/ios/Classes/NativeDeviceOrientationPlugin.h
@@ -1,4 +1,5 @@
 #import <Flutter/Flutter.h>
+#import <CoreMotion/CoreMotion.h>
 
 @interface NativeDeviceOrientationPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
 - (void)pause;

--- a/ios/Classes/NativeDeviceOrientationPlugin.h
+++ b/ios/Classes/NativeDeviceOrientationPlugin.h
@@ -1,4 +1,7 @@
 #import <Flutter/Flutter.h>
 
 @interface NativeDeviceOrientationPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
+- (void)pause;
+- (void)resume;
+
 @end

--- a/ios/Classes/NativeDeviceOrientationPlugin.m
+++ b/ios/Classes/NativeDeviceOrientationPlugin.m
@@ -12,6 +12,7 @@ id<IOrientationListener> listener;
 
 @interface NativeDeviceOrientationPlugin ()
 @property id observer;
+@property (copy) void (^orientationRetrieved)(NSString *orientation);
 @end
 
 @implementation NativeDeviceOrientationPlugin
@@ -71,10 +72,7 @@ id<IOrientationListener> listener;
 - (void) resume{
     // resume the listener
     if(listener != NULL){
-        [listener startOrientationListener:^(NSString *orientation) {
-            //todo sent back events to the listener
-            
-        }];
+        [listener startOrientationListener:_orientationRetrieved];
     }
 }
 
@@ -91,9 +89,10 @@ id<IOrientationListener> listener;
     }else{
         listener = [[OrientationListener alloc] init];
     }
-    [listener startOrientationListener:^(NSString *orientation) {
+    _orientationRetrieved = ^(NSString *orientation){
         events(orientation);
-    }];
+    };
+    [listener startOrientationListener:_orientationRetrieved];
     
     return NULL;
 }
@@ -106,105 +105,3 @@ id<IOrientationListener> listener;
 }
 
 @end
-
-//- (NSString*)getOrientation {
-//    UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
-//
-//    // exta check to make sure we don't return the FaceDown and FaceUp orientations but instead return the last known deviceOrientation.
-//    if(deviceOrientation != UIDeviceOrientationFaceDown && deviceOrientation != UIDeviceOrientationFaceUp) {
-//        lastDeviceOrientation = deviceOrientation;
-//    }
-//
-//    switch (lastDeviceOrientation) {
-//        case UIDeviceOrientationPortrait:
-//            return PORTRAIT_UP;
-//            break;
-//        case UIDeviceOrientationPortraitUpsideDown:
-//            return PORTRAIT_DOWN;
-//            break;
-//        case UIDeviceOrientationLandscapeLeft:
-//            return LANDSCAPE_LEFT;
-//            break;
-//        case UIDeviceOrientationLandscapeRight:
-//            return LANDSCAPE_RIGHT;
-//            break;
-//        case UIDeviceOrientationUnknown:
-//        default:
-//            return UNKNOWN;
-//            break;
-//    }
-//}
-
-//void initMotionManager() {
-//    if (!motionManager) {
-//        motionManager = [[CMMotionManager alloc] init];
-//    }
-//}
-
-//- (void)startDeviceMotionUpdates:(FlutterEventSink _Nonnull)events {
-//    initMotionManager();
-//    if([motionManager isDeviceMotionAvailable] == YES){
-//        motionManager.deviceMotionUpdateInterval = 0.1;
-//        [motionManager startDeviceMotionUpdatesToQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
-//
-//            NSString *orientation;
-//            if(fabs(data.gravity.x)>fabs(data.gravity.y)){
-//                // we are in landscape-mode
-//                if(data.gravity.x>=0){
-//                    NSLog(@"LandscapeRight");
-//                    orientation = LANDSCAPE_RIGHT;
-//                }
-//                else{
-//                    NSLog(@"LandscapeLeft");
-//                    orientation = LANDSCAPE_LEFT;
-//                }
-//            }
-//            else{
-//                // we are in portrait mode
-//                if(data.gravity.y>=0){
-//                    NSLog(@"PortraitDown");
-//                    orientation = PORTRAIT_DOWN;
-//                }
-//                else{
-//
-//                    NSLog(@"PortraitUp");
-//                    orientation = PORTRAIT_UP;
-//                }
-//
-//            }
-//            events(orientation);
-//
-//        }];
-//    }
-//}
-
-//- (void)startOrientationUpdates:(FlutterEventSink _Nonnull)events {
-//    UIDevice *device = [UIDevice currentDevice];
-//    [device beginGeneratingDeviceOrientationNotifications];
-//    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-//    self.observer = [nc addObserverForName:UIDeviceOrientationDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
-//        events([self getOrientation]);
-//    }];
-//    events([self getOrientation]);
-//}
-
-
-//void stopDeviceMotionUpdates(){
-//    if (motionManager != NULL && [motionManager isGyroActive] == YES) {
-//        [motionManager stopDeviceMotionUpdates];
-//    }
-//}
-
-
-//- (void)stopOrientationUpdates:(NSNotificationCenter *)nc {
-//    UIDevice *device = [UIDevice currentDevice];
-//    [device endGeneratingDeviceOrientationNotifications];
-//    [nc removeObserver:self.observer];
-//    self.observer = NULL;
-//}
-
-
-
-
-
-

--- a/ios/Classes/NativeDeviceOrientationPlugin.m
+++ b/ios/Classes/NativeDeviceOrientationPlugin.m
@@ -62,10 +62,25 @@ UIDeviceOrientation lastDeviceOrientation = UIDeviceOrientationUnknown;
     
     if ([@"getOrientation" isEqualToString:call.method]) {
         result([self getOrientation]);
-    } else {
+    } else if([@"pause" isEqualToString:call.method]){
+        [self pause];
+        result(NULL);
+    }else if([@"resume" isEqualToString:call.method]){
+        [self resume];
+        result(NULL);
+    }else {
         result(FlutterMethodNotImplemented);
     }
 }
+
+- (void) pause{
+    
+}
+
+- (void) resume{
+    
+}
+
 
 - (FlutterError* _Nullable)onListenWithArguments:(id _Nullable)arguments
                                        eventSink:(FlutterEventSink)events {

--- a/ios/Classes/Orientation.h
+++ b/ios/Classes/Orientation.h
@@ -1,0 +1,9 @@
+#ifndef Orientation_h
+#define Orientation_h
+
+extern NSString* const PORTRAIT_UP;
+extern NSString* const PORTRAIT_DOWN;
+extern NSString* const LANDSCAPE_LEFT;
+extern NSString* const LANDSCAPE_RIGHT;
+extern NSString* const UNKNOWN;
+#endif /* Orientation_h */

--- a/ios/Classes/Orientation.m
+++ b/ios/Classes/Orientation.m
@@ -1,0 +1,14 @@
+//
+//  Orientation.m
+//  native_device_orientation
+//
+//  Created by Sebastiaan de Smet on 21/01/2019.
+//
+
+#import <Foundation/Foundation.h>
+
+NSString* const PORTRAIT_UP = @"PortraitUp";
+NSString* const PORTRAIT_DOWN = @"PortraitDown";
+NSString* const LANDSCAPE_LEFT = @"LandscapeLeft";
+NSString* const LANDSCAPE_RIGHT = @"LandscapeRight";
+NSString* const UNKNOWN = @"Unknown";

--- a/ios/Classes/OrientationListener.h
+++ b/ios/Classes/OrientationListener.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import "Orientation.h"
+#import "IOrientationListener.h"
+
+#ifndef OrientationListener_h
+#define OrientationListener_h
+@interface OrientationListener : NSObject <IOrientationListener>
+
+@property id observer;
+
+@end
+
+#endif /* OrientationListener_h */

--- a/ios/Classes/OrientationListener.m
+++ b/ios/Classes/OrientationListener.m
@@ -1,0 +1,66 @@
+//
+//  OrientationListener.m
+//  native_device_orientation
+//
+//  Created by Sebastiaan de Smet on 21/01/2019.
+//
+
+
+#import "OrientationListener.h"
+
+@implementation OrientationListener
+
+UIDeviceOrientation lastDeviceOrientation = UIDeviceOrientationUnknown;
+
+- (void)startOrientationListener:(void (^)(NSString* orientation)) orientationRetrieved {
+    UIDevice *device = [UIDevice currentDevice];
+    [device beginGeneratingDeviceOrientationNotifications];
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    self.observer = [nc addObserverForName:UIDeviceOrientationDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
+        orientationRetrieved([self getDeviceOrientation]);
+    }];
+    orientationRetrieved([self getDeviceOrientation]);
+}
+
+- (void) getOrientation:(void (^)(NSString* orientation)) orientationRetrieved{
+    NSString* orientation = [self getDeviceOrientation];
+    orientationRetrieved(orientation);
+}
+
+- (NSString*)getDeviceOrientation {
+    UIDeviceOrientation deviceOrientation = [[UIDevice currentDevice] orientation];
+    
+    // exta check to make sure we don't return the FaceDown and FaceUp orientations but instead return the last known deviceOrientation.
+    if(deviceOrientation != UIDeviceOrientationFaceDown && deviceOrientation != UIDeviceOrientationFaceUp) {
+        lastDeviceOrientation = deviceOrientation;
+    }
+    
+    switch (lastDeviceOrientation) {
+        case UIDeviceOrientationPortrait:
+            return PORTRAIT_UP;
+            break;
+        case UIDeviceOrientationPortraitUpsideDown:
+            return PORTRAIT_DOWN;
+            break;
+        case UIDeviceOrientationLandscapeLeft:
+            return LANDSCAPE_LEFT;
+            break;
+        case UIDeviceOrientationLandscapeRight:
+            return LANDSCAPE_RIGHT;
+            break;
+        case UIDeviceOrientationUnknown:
+        default:
+            return UNKNOWN;
+            break;
+    }
+}
+
+- (void)stopOrientationListener {
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    UIDevice *device = [UIDevice currentDevice];
+    [device endGeneratingDeviceOrientationNotifications];
+    [nc removeObserver:self.observer];
+    self.observer = NULL;
+}
+
+@end

--- a/ios/Classes/SensorListener.h
+++ b/ios/Classes/SensorListener.h
@@ -1,0 +1,13 @@
+#import <CoreMotion/CoreMotion.h>
+#import <Foundation/Foundation.h>
+#import "SensorListener.h"
+#import "IOrientationListener.h"
+#import "Orientation.h"
+
+#ifndef SensorListener_h
+#define SensorListener_h
+@interface SensorListener : NSObject <IOrientationListener>
+
+@end
+
+#endif /* SensorListener_h */

--- a/ios/Classes/SensorListener.m
+++ b/ios/Classes/SensorListener.m
@@ -20,23 +20,18 @@ void initMotionManager() {
             if(fabs(data.gravity.x)>fabs(data.gravity.y)){
                 // we are in landscape-mode
                 if(data.gravity.x>=0){
-                    NSLog(@"LandscapeRight");
                     orientation = LANDSCAPE_RIGHT;
                 }
                 else{
-                    NSLog(@"LandscapeLeft");
                     orientation = LANDSCAPE_LEFT;
                 }
             }
             else{
                 // we are in portrait mode
                 if(data.gravity.y>=0){
-                    NSLog(@"PortraitDown");
                     orientation = PORTRAIT_DOWN;
                 }
                 else{
-                    
-                    NSLog(@"PortraitUp");
                     orientation = PORTRAIT_UP;
                 }
                 

--- a/ios/Classes/SensorListener.m
+++ b/ios/Classes/SensorListener.m
@@ -1,0 +1,69 @@
+#import "SensorListener.h"
+
+@implementation SensorListener
+
+CMMotionManager* motionManager;
+
+void initMotionManager() {
+    if (!motionManager) {
+        motionManager = [[CMMotionManager alloc] init];
+    }
+}
+
+- (void)startOrientationListener:(void (^)(NSString* orientation)) orientationRetrieved {
+    initMotionManager();
+    if([motionManager isDeviceMotionAvailable] == YES){
+        motionManager.deviceMotionUpdateInterval = 0.1;
+        [motionManager startDeviceMotionUpdatesToQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
+            
+            NSString *orientation;
+            if(fabs(data.gravity.x)>fabs(data.gravity.y)){
+                // we are in landscape-mode
+                if(data.gravity.x>=0){
+                    NSLog(@"LandscapeRight");
+                    orientation = LANDSCAPE_RIGHT;
+                }
+                else{
+                    NSLog(@"LandscapeLeft");
+                    orientation = LANDSCAPE_LEFT;
+                }
+            }
+            else{
+                // we are in portrait mode
+                if(data.gravity.y>=0){
+                    NSLog(@"PortraitDown");
+                    orientation = PORTRAIT_DOWN;
+                }
+                else{
+                    
+                    NSLog(@"PortraitUp");
+                    orientation = PORTRAIT_UP;
+                }
+                
+            }
+            orientationRetrieved(orientation);
+
+        }];
+    }
+}
+
+- (void) getOrientation:(void (^)(NSString* orientation)) orientationRetrieved{
+    
+    [self startOrientationListener:^(NSString *orientation) {
+        orientationRetrieved(orientation);
+        
+        // we have received a orientation stop the listener. We only want to return one orientation
+        [self stopOrientationListener];
+    }];
+}
+
+- (void)stopOrientationListener {
+    if (motionManager != NULL && [motionManager isDeviceMotionActive] == YES) {
+        [motionManager stopDeviceMotionUpdates];
+    }
+}
+
+
+@end
+
+

--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -53,8 +53,6 @@ Future<void> resume() async{
         'useSensor': _useSensor,
       };
       _onNativeOrientationChanged = _eventChannel.receiveBroadcastStream(params).map((dynamic event) {
-        print("new orientation received");
-
         return _fromString(event);
       });
     }

--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -37,12 +37,24 @@ class NativeDeviceOrientationCommunicator {
     return _fromString(orientation);
   }
 
+  // these methods are needed to pause listening to sensorRequests when the app goes to background
+  Future<void> pause() async{
+    await _methodChannel.invokeMethod('pause');
+}
+
+// this method resumes listening to sensorEvents when the app goes to the foreground
+Future<void> resume() async{
+    await _methodChannel.invokeMethod('resume');
+}
+
   Stream<NativeDeviceOrientation> get onOrientationChanged {
     if (_onNativeOrientationChanged == null) {
       final Map<String, dynamic> params = <String, dynamic>{
         'useSensor': _useSensor,
       };
       _onNativeOrientationChanged = _eventChannel.receiveBroadcastStream(params).map((dynamic event) {
+        print("new orientation received");
+
         return _fromString(event);
       });
     }
@@ -95,12 +107,51 @@ class NativeDeviceOrientationReader extends StatefulWidget {
   State<StatefulWidget> createState() => new NativeDeviceOrientationReaderState();
 }
 
-class NativeDeviceOrientationReaderState extends State<NativeDeviceOrientationReader> {
-//  NativeDeviceOrientationCommunicator deviceOrientation = new NativeDeviceOrientationCommunicator();
+class NativeDeviceOrientationReaderState extends State<NativeDeviceOrientationReader> with WidgetsBindingObserver {
+  NativeDeviceOrientationCommunicator deviceOrientation;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // we need to listen to the state of the application.
+    // we shouldn't listen to orientation events when the app is in the background.
+    switch(state){
+      case AppLifecycleState.inactive:
+        // Another app has focus, for example because the control center is opened,
+      // or we have opened teh app as a split-screen app. The app however might still be visible.
+      // we would still like to retrieve orientationChanges
+        break;
+      case AppLifecycleState.paused:
+        // pause the listener
+        deviceOrientation.pause();
+        break;
+      case AppLifecycleState.resumed:
+        // resume the listener
+      deviceOrientation.resume();
+        break;
+      case AppLifecycleState.suspending:
+        // unused on iOS on Android the app will be suspbended.
+        break;
+    }
+
+
+  }
+
 
   @override
   Widget build(BuildContext context) {
-    NativeDeviceOrientationCommunicator deviceOrientation =
+    deviceOrientation =
         new NativeDeviceOrientationCommunicator(useSensor: widget.useSensor);
 
     return new LayoutBuilder(builder: (context, constraints) {


### PR DESCRIPTION
- added pause and resume method to the NativeDeviceOrientationCommunicator. When the pause method is called we stop listening to orientation-events since the app is in the background. When we call resume we start listening again.
-  The NativeDeviceOrientationReader calls the pause- and resume-methods automatically. The user doesn't need to implement it anymore.
- added support for the useSensor parameter for iOS.
- separated the logic of the iOS-version in separate classes, comparable to the Android-version