### PR TITLE
migration to androidx

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'native_device_orientation'
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,1 @@
 rootProject.name = 'native_device_orientation'
-android.enableJetifier=true
-android.useAndroidX=true


### PR DESCRIPTION
latest stable flutter 1.2.1 has a breaking change and forces applications to migrate from android.support to androidx packages. this pull request should do the trick

more info here:

1. https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility
2. https://medium.com/@gabrc52/how-to-migrate-your-flutter-app-to-androidx-1202ad43c8c8