### PR TITLE
Fixed an issue on Android where if the phone is parallel to the ground, the sensor device orientation that would come back is always PortraitUp instead of Unknown

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/nativedeviceorientation/OrientationReader.java
+++ b/android/src/main/java/com/github/rmtmckenzie/nativedeviceorientation/OrientationReader.java
@@ -70,6 +70,10 @@ public class OrientationReader {
     }
 
     public Orientation calculateSensorOrientation(int angle) {
+        if (angle == -1) {
+            return Orientation.Unknown;
+        }
+
         Orientation returnOrientation;
 
         final int tolerance = 45;


### PR DESCRIPTION
Hello there.

The Android documentation of OrientationEventListener(https://developer.android.com/reference/android/view/OrientationEventListener.html) specifies that the stream can return ORIENTATION_UNKNOWN if "Returned from onOrientationChanged when the device orientation cannot be determined (typically when the device is in a close to flat position)."

What I've found is that the orientation stream when useSensor is true returns PortraitUp if the Android OrientationEventListener returns Orientation.Unknown(when for example the phone is parallel to the ground), so I thought I would open a quick PR that fixes that. 