### PR TITLE
Fix Invalid "android" plugin specification

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,7 @@ flutter:
   plugin:
     platforms:
       android:
-        package:
-          package: com.github.rmtmckenzie.native_device_orientation
-          pluginClass: NativeDeviceOrientationPlugin
+        package: com.github.rmtmckenzie.native_device_orientation
+        pluginClass: NativeDeviceOrientationPlugin
       ios:
         pluginClass: NativeDeviceOrientationPlugin


### PR DESCRIPTION
Fixes issue #20 Invalid "android" plugin specification when running `flutter pub get`