### PR TITLE
Allow returning "Unknown" orientation from Android

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/OrientationReader.java
+++ b/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/OrientationReader.java
@@ -71,6 +71,9 @@ public class OrientationReader {
     }
 
     public Orientation calculateSensorOrientation(int angle) {
+        if (angle == -1) {
+            return Orientation.Unknown;
+        }
         Orientation returnOrientation;
 
         final int tolerance = 45;

--- a/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/OrientationReader.java
+++ b/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/OrientationReader.java
@@ -2,6 +2,7 @@ package com.github.rmtmckenzie.native_device_orientation;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.view.OrientationEventListener;
 import android.view.Surface;
 import android.view.WindowManager;
 
@@ -71,7 +72,7 @@ public class OrientationReader {
     }
 
     public Orientation calculateSensorOrientation(int angle) {
-        if (angle == -1) {
+        if (angle == OrientationEventListener.ORIENTATION_UNKNOWN) {
             return Orientation.Unknown;
         }
         Orientation returnOrientation;

--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -62,7 +62,7 @@ class NativeDeviceOrientationCommunicator {
     bool useSensor = false,
     NativeDeviceOrientation unknownSubstitute = NativeDeviceOrientation.portraitUp,
   }) {
-    if (_stream == null || _stream.useSensor != useSensor) {
+    if (_stream == null || _stream!.useSensor != useSensor) {
       final params = <String, dynamic>{
         'useSensor': useSensor,
       };

--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -43,13 +43,17 @@ class NativeDeviceOrientationCommunicator {
   NativeDeviceOrientationCommunicator.private(
       this._methodChannel, this._eventChannel);
 
-  Future<NativeDeviceOrientation> orientation({bool useSensor = false}) async {
+  Future<NativeDeviceOrientation> orientation({
+    bool useSensor = false,
+    NativeDeviceOrientation unknownSubstitute = NativeDeviceOrientation.portraitUp,
+  }) async {
     final params = <String, dynamic>{
       'useSensor': useSensor,
     };
-    final orientation =
+    final orientationString =
         await _methodChannel.invokeMethod('getOrientation', params);
-    return _fromString(orientation);
+    final orientation = _fromString(orientationString);
+    return (orientation == NativeDeviceOrientation.unknown) ? unknownSubstitute : orientation;
   }
 
   // these methods are needed to pause listening to sensorRequests when the app goes to background
@@ -62,8 +66,10 @@ class NativeDeviceOrientationCommunicator {
     await _methodChannel.invokeMethod('resume');
   }
 
-  Stream<NativeDeviceOrientation> onOrientationChanged(
-      {bool useSensor = false}) {
+  Stream<NativeDeviceOrientation> onOrientationChanged({
+    bool useSensor = false,
+    NativeDeviceOrientation unknownSubstitute = NativeDeviceOrientation.portraitUp,
+  }) {
     if (_stream == null || _stream.useSensor != useSensor) {
       final params = <String, dynamic>{
         'useSensor': useSensor,
@@ -75,7 +81,9 @@ class NativeDeviceOrientationCommunicator {
           }),
           useSensor: useSensor);
     }
-    return _stream.stream;
+    return _stream.stream.map(
+            (orientation) => (orientation == NativeDeviceOrientation.unknown) ? unknownSubstitute : orientation
+    );
   }
 
   NativeDeviceOrientation _fromString(String orientationString) {


### PR DESCRIPTION
# What is this change
This PR handles the [ORIENTATION_UNKNOWN](https://developer.android.com/reference/android/view/OrientationEventListener#ORIENTATION_UNKNOWN) state returned by Android and returns the "Unknown" orientation instead of the previous default to "PortraitUp"

To preserve previous functionality, each orientation getter/listener method now has an included `unknownSubstitute` parameter. The default value is `portraitUp` which should preserve the current behavior, but allows developers to change this at their will.

# Why this way
I opted to do the logic of substitution in Dart as opposed to Java as I feel additional logic should live there. The Java code with this change returns as superset of information (as opposed to before this change). Writing native code is generally more of a escape hatch when necessary for functionality or when performance deems the situation as required. Neither of these cases apply here.

# Background
See discussion https://github.com/rmtmckenzie/flutter_native_device_orientation/pull/12#issuecomment-734114697
tl;dr : Some developers need to know when Android phones are flat