### PR TITLE
New Widget class that monitors orientation itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,15 @@ doesn't to much more than simply tell you whether the window is oriented landsca
 This has been tested less thoroughly than other parts of the plugin so your mileage may vary and
 if you run into any issues please open an issue!
 
-## Using the plugin - built-in widget 
+## Using the plugin - built-in "reader" widget 
 
-There are two ways of using the plugin. The most basic is what is shown in the example code;
- this entails encapsulating your code in a `NativeDeviceOrientationReader` widget, and then
- using `NativeDeviceOrientationReader.orientation(context);` in a widget encapsulated
- within the context.
+There are three ways of using the plugin. The simplest entails encapsulating your code in a
+`NativeDeviceOrientationReader` widget, and then using
+`NativeDeviceOrientationReader.orientation(context);` in a widget encapsulated within the context.
 
 This allows you to control when the device starts listening for orientation changes (which could
 use a bit of energy) by deciding where the `NativeDeviceOrientationReader` is instantiated,
 while being able to access the orientation in a simple way.
-
 
 _Note that there could be a very slight time between when the `NativeDeviceOrientationReader` widget 
 is instantiated and when the orientation is read where the widget could be built with an incorrect
@@ -44,8 +42,25 @@ orientation; it uses flutter's method of size until the first message it receive
 back from the native code (which should be fairly immediate anyways). It
 assumes that landscape is right and portrait is upright during this time._
 
-See example and source code for more details.
+See the source code for more details.
 
+## Using the plugin - built-in "oriented" widget
+
+The second approach is more involved, but involves slightly less boilerplate, and may be a bit more
+obvious to use. It wraps the `NativeDeviceOrientationReader` widget, then automatically checks the
+orientation for you. Instead of passing in a single `builder` function, you pass one for each
+orientation you wish to define: `landscapeLeft`, `landscapeRight`, `portraitUp`, and `portaitDown`
+are the most obvious, followed by simply `landscape` and `portrait` for situations where you don't
+care to define different layouts for either of those, and finally the (**required**) `fallback`,
+used in cases where either you don't have a more specific builder defined, or something goes horribly
+horribly wrong.
+
+You sacrifice a bit of control over when to actually retrieve the orientation info in exchange for
+the plugin handling orientation updates automatically. Since this approach does a bit more hand
+holding, processing things like `NativeDeviceOrientation.unknown` for you, it's the approach in the
+example app.
+
+See example and source code for more details.
 ## Using the plugin - directly
 
 It is also possible to bypass the helper widget to access the native calls directly.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,11 +22,27 @@ class _MyAppState extends State<MyApp> {
               Switch(value: useSensor, onChanged: (val) => setState(() => useSensor = val)),
             ],
           ),
-          body: NativeDeviceOrientationReader(
-            builder: (context) {
-              final orientation = NativeDeviceOrientationReader.orientation(context);
-              print('Received new orientation: $orientation');
-              return Center(child: Text('Native Orientation: $orientation\n'));
+          body: NativeDeviceOrientedWidget(
+            landscape: (context) {
+              return Center(child: Text('Native Orientation: Landscape (Unknown Side)\n'));
+            },
+            landscapeLeft: (context) {
+              return Center(child: Text('Native Orientation: Landscape Left\n'));
+            },
+            landscapeRight: (context) {
+              return Center(child: Text('Native Orientation: Landscape Right\n'));
+            },
+            portrait: (context) {
+              return Center(child: Text('Native Orientation: Portrait (Unknown Side)\n'));
+            },
+            portraitUp: (context) {
+              return Center(child: Text('Native Orientation: Portrait Up\n'));
+            },
+            portraitDown: (context) {
+              return Center(child: Text('Native Orientation: Portrait Down\n'));
+            },
+            fallback: (context) {
+              return Center(child: Text('Native Orientation: Unknown\n'));
             },
             useSensor: useSensor,
           ),

--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -84,6 +84,62 @@ class NativeDeviceOrientationCommunicator {
   }
 }
 
+class NativeDeviceOrientedWidget extends StatelessWidget {
+  const NativeDeviceOrientedWidget({
+    Key? key,
+    this.useSensor = false,
+    this.landscape,
+    this.landscapeLeft,
+    this.landscapeRight,
+    this.portrait,
+    this.portraitUp,
+    this.portraitDown,
+    required this.fallback,
+  }) : super(key: key);
+
+  final bool useSensor;
+  final Widget Function(BuildContext)? landscape;
+  final Widget Function(BuildContext)? landscapeLeft;
+  final Widget Function(BuildContext)? landscapeRight;
+  final Widget Function(BuildContext)? portrait;
+  final Widget Function(BuildContext)? portraitUp;
+  final Widget Function(BuildContext)? portraitDown;
+  final Widget Function(BuildContext) fallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return NativeDeviceOrientationReader(
+        builder: (context) {
+          final orientation =
+              NativeDeviceOrientationReader.orientation(context);
+
+          switch (orientation) {
+            case NativeDeviceOrientation.landscapeLeft:
+              return Builder(builder: landscapeLeft ?? landscape ?? fallback);
+            case NativeDeviceOrientation.landscapeRight:
+              return Builder(builder: landscapeRight ?? landscape ?? fallback);
+            case NativeDeviceOrientation.portraitUp:
+              return Builder(builder: portraitUp ?? portrait ?? fallback);
+            case NativeDeviceOrientation.portraitDown:
+              return Builder(builder: portraitDown ?? portrait ?? fallback);
+            case NativeDeviceOrientation.unknown:
+            default:
+              return OrientationBuilder(builder: (buildContext, orientation) {
+                switch (orientation) {
+                  case Orientation.landscape:
+                    return Builder(builder: landscape ?? fallback);
+                  case Orientation.portrait:
+                    return Builder(builder: portrait ?? fallback);
+                  default:
+                    return Builder(builder: fallback);
+                }
+              });
+          }
+        },
+        useSensor: useSensor);
+  }
+}
+
 class NativeDeviceOrientationReader extends StatefulWidget {
   const NativeDeviceOrientationReader({
     Key? key,
@@ -192,12 +248,18 @@ class NativeDeviceOrientationReaderState extends State<NativeDeviceOrientationRe
 class _InheritedNativeDeviceOrientation extends InheritedWidget {
   final NativeDeviceOrientation? nativeOrientation;
 
-  const _InheritedNativeDeviceOrientation({
+  _InheritedNativeDeviceOrientation._({
     Key? key,
     required this.nativeOrientation,
     required Widget child,
-  })   : assert(nativeOrientation != null),
-        super(key: key, child: child);
+  }) : super(key: key, child: child);
+
+  factory _InheritedNativeDeviceOrientation({required NativeDeviceOrientation? nativeOrientation, required Widget child}) {
+    return _InheritedNativeDeviceOrientation._(
+      nativeOrientation: nativeOrientation ?? NativeDeviceOrientation.unknown,
+      child: child,
+    );
+  }
 
   @override
   bool updateShouldNotify(_InheritedNativeDeviceOrientation oldWidget) =>


### PR DESCRIPTION
I'm providing this additional widget because it reduces a lot of code duplication, and because it moves the logic for deciding _when_ to render different layouts into the widget itself, letting the developer focus on _how_ to render those layouts instead. A similar principle underlies things like MVC (and its relatives/derivatives), HTML/CSS/JS, and so forth: keep logic and presentation separate. I updated the example to show how this new widget is used, and the `README.md` to describe the new approach in addition to the others.

I love the design of this plugin, where it allows devs to reach in and grab the functionality from as low a level as they need for their specific use case(s)! I just thought I'd contribute a third, higher layer on top of the two already presented. I feel like it's more in the spirit of Flutter's Widget-centric design, as well, but that's just an opinion, and we all know how we feel about those. 😀 