### PR TITLE
Remove verbose log

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
@@ -117,10 +117,8 @@ public class NativeDeviceOrientationPlugin implements FlutterPlugin {
       };
 
       if(useSensor){
-        Log.i("NDOP", "listening using sensor listener");
         listener = new SensorOrientationListener(context, callback);
       }else{
-        Log.i("NDOP", "listening using window listener");
         listener = new OrientationListener(reader, context, callback);
       }
       listener.startOrientationListener();


### PR DESCRIPTION
This plugin makes some very verbose logs `listening using window listener` when using your other plugin for qr code scanning. This causes way too much spam and makes the console unusable.

An easy solution is to remove these logs. Do you think they are essential info for developers?

Other solutions might be to add LogLevel info, or to log this only once (with a flag). But I have a feeling that just removing it is fine. What do you think?