### PR TITLE
Add a getter that returns `DeviceOrientation` to `NativeDeviceOrientation`

### DIFF
--- a/lib/native_device_orientation.dart
+++ b/lib/native_device_orientation.dart
@@ -3,7 +3,31 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-enum NativeDeviceOrientation { portraitUp, portraitDown, landscapeLeft, landscapeRight, unknown }
+enum NativeDeviceOrientation {
+  portraitUp,
+  portraitDown,
+  landscapeLeft,
+  landscapeRight,
+  unknown;
+
+  const NativeDeviceOrientation();
+
+  /// Returns corresponding [DeviceOrientation] for this [NativeDeviceOrientation]
+  DeviceOrientation? get deviceOrientation {
+    switch (this) {
+      case NativeDeviceOrientation.portraitUp:
+        return DeviceOrientation.portraitUp;
+      case NativeDeviceOrientation.portraitDown:
+        return DeviceOrientation.portraitDown;
+      case NativeDeviceOrientation.landscapeLeft:
+        return DeviceOrientation.landscapeLeft;
+      case NativeDeviceOrientation.landscapeRight:
+        return DeviceOrientation.landscapeRight;
+      case NativeDeviceOrientation.unknown:
+        return null;
+    }
+  }
+}
 
 class _OrientationStream {
   final Stream<NativeDeviceOrientation> stream;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.2.1
 homepage: https://github.com/rmtmckenzie/flutter_native_device_orientation
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=2.17.0 <4.0.0"
   flutter: ">=2.0.0"
 
 dependencies:


### PR DESCRIPTION
## Why

In many cases one would want to convert `NativeDeviceOrientation` to `DeviceOrientation` because `DeviceOrientation` is more widely used.

## Changes made

- Added a getter on `NativeDeviceOrientation` enum that converts `NativeDeviceOrientation` to `DeviceOrientation`.
- Raised minimum required Dart SDK version to use an enhanced enum feature.

I think this change offers better experience so please consider merging if you feel the same way :)