### PR TITLE
Fix crash iOS

### DIFF
--- a/ios/Classes/NativeDeviceOrientationPlugin.swift
+++ b/ios/Classes/NativeDeviceOrientationPlugin.swift
@@ -32,7 +32,8 @@ public class NativeDeviceOrientationPlugin: NSObject, FlutterPlugin {
     case "getOrientation":
       getOrientation(useSensor: argReader.bool(key: "useSensor") ?? false, result: result)
     case "pause":
-      result(pause())
+      pause()
+      result(nil)
     case "resume":
       result(resume())
     default:


### PR DESCRIPTION
iOS is crashing because the pause function is of void type; It's trying to send it to methodChannel.
```swift
result(pause())
```
