### PR TITLE
fix: leaked intent receiver

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
@@ -39,6 +39,10 @@ public class NativeDeviceOrientationPlugin implements FlutterPlugin, MethodCallH
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (listener != null) {
+      listener.stopOrientationListener();
+      listener = null;
+    }
     channel.setMethodCallHandler(null);
     eventChannel.setStreamHandler(null);
   }
@@ -50,6 +54,10 @@ public class NativeDeviceOrientationPlugin implements FlutterPlugin, MethodCallH
 
   @Override
   public void onDetachedFromActivity() {
+    if (listener != null) {
+      listener.stopOrientationListener();
+      listener = null;
+    }
     this.activity = null;
   }
 
@@ -136,7 +144,9 @@ public class NativeDeviceOrientationPlugin implements FlutterPlugin, MethodCallH
 
   @Override
   public void onCancel(Object arguments) {
-    listener.stopOrientationListener();
-    listener = null;
+    if (listener != null) {
+      listener.stopOrientationListener();
+      listener = null;
+    }
   }
 }


### PR DESCRIPTION
## Fix leaked `OrientationListener` broadcast receiver on Android

This PR ensures the Android implementation of `flutter_native_device_orientation` properly unregisters its broadcast receiver to prevent `IntentReceiverLeaked` errors when the hosting activity or engine is torn down.

### Changes

- Stop and clear the active `IOrientationListener` in `onDetachedFromActivity()` before nulling the `Activity`, so the `BroadcastReceiver` registered in `OrientationListener.startOrientationListener()` is always unregistered when the activity is destroyed or detached (including config changes).
- Stop and clear the listener in `onDetachedFromEngine()` to cover the case where the engine is torn down while still attached to an activity.
- Make `onCancel()` null-safe by checking for a non-null listener before calling `stopOrientationListener()`.

### Result

Prevents `IntentReceiverLeaked` warnings such as:

> Activity ... has leaked IntentReceiver com.github.rmtmckenzie.native_device_orientation.OrientationListener$1 ... Are you missing a call to unregisterReceiver()?