### PR TITLE
fix(android): ignore null sensor orientation events

### DIFF
--- a/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
+++ b/android/src/main/java/com/github/rmtmckenzie/native_device_orientation/NativeDeviceOrientationPlugin.java
@@ -129,8 +129,12 @@ public class NativeDeviceOrientationPlugin implements FlutterPlugin, MethodCallH
       }
     }
 
-    // initialize the callback. It is the same for both listeners.
-    IOrientationListener.OrientationCallback callback = orientation -> eventSink.success(orientation.name());
+    // The sensor listener can be restarted before Android reports its first
+    // orientation, so ignore that null startup value instead of crashing.
+    IOrientationListener.OrientationCallback callback = orientation -> {
+      if (orientation == null) return;
+      eventSink.success(orientation.name());
+    };
 
     if (useSensor) {
       Log.i("NDOP", "listening using sensor listener");


### PR DESCRIPTION
Fixes #49.

The Android sensor listener can be restarted before it has received its first orientation value. In that state `lastOrientation` is still null, but the plugin callback immediately calls `orientation.name()`, causing a `NullPointerException`.

This change ignores null startup orientation values at the platform callback boundary and continues emitting valid orientation events once Android reports one.