### PR TITLE
fix: raise SPM iOS platform min to 13.0

### DIFF
--- a/ios/native_device_orientation/Package.swift
+++ b/ios/native_device_orientation/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "native_device_orientation",
     platforms: [
-        .iOS("11.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "native-device-orientation", targets: ["native_device_orientation"])


### PR DESCRIPTION
Flutter's Swift Package Manager integration generates a `FlutterFramework` Swift package that declares `.iOS("13.0")`. Since this plugin depends on it while declaring a lower platform minimum, Xcode fails the build:

```
Target Integrity (Xcode): The package product 'FlutterFramework' requires minimum
platform version 13.0 for the iOS platform, but this target supports 11.0
```

Raising the SPM platform minimum to 13.0 fixes it. The podspec is left untouched — CocoaPods builds are unaffected because Flutter's podhelper already raises pod deployment targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)